### PR TITLE
Removed key(s) spec tags

### DIFF
--- a/lib/simple_rsa.dart
+++ b/lib/simple_rsa.dart
@@ -7,6 +7,7 @@ const MethodChannel _channel =
 
 Future<String> encryptString(String txt, String publicKey) async {
   try {
+    publicKey = publicKey.replaceAll("-----BEGIN PUBLIC KEY-----", "").replaceAll("-----END PUBLIC KEY-----", "");
     final String result = await _channel
         .invokeMethod('encrypt', {"txt": txt, "publicKey": publicKey});
     return result;
@@ -17,6 +18,8 @@ Future<String> encryptString(String txt, String publicKey) async {
 
 Future<String> decryptString(String txt, String privateKey) async {
   try {
+    privateKey = privateKey.replaceAll("-----BEGIN PRIVATE KEY-----", "").replaceAll("-----END PRIVATE KEY-----", "");
+    privateKey = privateKey.replaceAll("-----BEGIN RSA PRIVATE KEY-----", "").replaceAll("-----END RSA PRIVATE KEY-----", "");
     final String result = await _channel
         .invokeMethod('decrypt', {"txt": txt, "privateKey": privateKey});
     return result;
@@ -27,6 +30,8 @@ Future<String> decryptString(String txt, String privateKey) async {
 
 Future<String> signString(String plainText, String privateKey) async {
   try {
+    privateKey = privateKey.replaceAll("-----BEGIN PRIVATE KEY-----", "").replaceAll("-----END PRIVATE KEY-----", "");
+    privateKey = privateKey.replaceAll("-----BEGIN RSA PRIVATE KEY-----", "").replaceAll("-----END RSA PRIVATE KEY-----", "");
     final String result = await _channel
         .invokeMethod('sign', {"plainText": plainText, "privateKey": privateKey});
     return result;
@@ -37,6 +42,7 @@ Future<String> signString(String plainText, String privateKey) async {
 
 Future<bool> verifyString(String plainText, String signature, String publicKey) async {
   try {
+    publicKey = publicKey.replaceAll("-----BEGIN PUBLIC KEY-----", "").replaceAll("-----END PUBLIC KEY-----", "");
     final bool result = await _channel
         .invokeMethod('verify', {"plainText": plainText, "signature": signature, "publicKey": publicKey});
     return result;
@@ -47,6 +53,7 @@ Future<bool> verifyString(String plainText, String signature, String publicKey) 
 
 Future<String> decryptStringWithPublicKey(String plainText, String signature, String publicKey) async {
   try {
+    publicKey = publicKey.replaceAll("-----BEGIN PUBLIC KEY-----", "").replaceAll("-----END PUBLIC KEY-----", "");
     final String result = await _channel
         .invokeMethod('decryptWithPublicKey', {"plainText": plainText, "publicKey": publicKey});
     return result;


### PR DESCRIPTION
This update doesn't require the developers to remove prefix and suffix tags especially when using/reading key data from pem files